### PR TITLE
feat/Access token now being attached to Koa's context

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -10,3 +10,4 @@ DB_PASS=
 
 # JWT Secret
 JWT_SECRET=test
+JWT_EXPIRATION=10h

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -12,6 +12,10 @@ import {
   sendResult,
 } from 'graphql-helix';
 import { schema } from './schema/schema';
+import {
+  findCurrentUser,
+  IAuthContext,
+} from './modules/User/auth/findCurrentUser';
 
 export const app = new Koa();
 
@@ -20,7 +24,10 @@ app.use(cors());
 app.use(logger());
 app.use(routes.routes());
 
-app.use(async (ctx) => {
+app.use(async (ctx: IAuthContext) => {
+  const user = await findCurrentUser(ctx);
+  ctx.user = user;
+
   // Create a generic Request object that can be consumed by Graphql Helix's API
   const request = {
     body: ctx.request.body,
@@ -48,6 +55,7 @@ app.use(async (ctx) => {
     contextFactory: () => {
       return {
         ...ctx.req.headers,
+        user: ctx.user,
       };
     },
   });

--- a/packages/server/src/modules/User/UserMutations/createUser.ts
+++ b/packages/server/src/modules/User/UserMutations/createUser.ts
@@ -48,12 +48,14 @@ export const createUser = mutationWithClientMutationId({
       password: hashPassword,
     });
 
-    await newUser.save();
+    const { id, fullName } = newUser;
 
-    const token = jwt.sign({ email }, process.env.JWT_SECRET!, {
-      expiresIn: '10h',
+    const token = jwt.sign({ id, email }, process.env.JWT_SECRET!, {
+      expiresIn: process.env.JWT_EXPIRATION,
     });
 
-    return { user: newUser, token };
+    await newUser.save();
+
+    return { user: { email, fullName }, token };
   },
 });

--- a/packages/server/src/modules/User/auth/findCurrentUser.ts
+++ b/packages/server/src/modules/User/auth/findCurrentUser.ts
@@ -1,0 +1,30 @@
+import { Context } from 'koa';
+import { JwtPayload, verify } from 'jsonwebtoken';
+
+interface ITokenPayload {
+  id: string;
+  email: string;
+}
+
+export interface IAuthContext extends Context {
+  user: ITokenPayload | null;
+}
+
+export async function findCurrentUser(ctx: Context) {
+  const { authorization } = ctx.headers;
+
+  if (!authorization) return null;
+
+  const accessToken = authorization.replace('Bearer', '').trim();
+
+  try {
+    const { id, email } = verify(
+      accessToken,
+      process.env.JWT_SECRET!,
+    ) as JwtPayload & ITokenPayload;
+
+    return { id, email };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
In this PR I've just created a findUser() function that decodes the JWT being sent to the server and attaches it to Koa's context. Now all queries and mutations will be able to know information about the user sending requests and also protect themselves accordingly.