### PR TITLE
Feat/Recipes model, queries and mutations created

### DIFF
--- a/packages/server/src/graphql/errorField.ts
+++ b/packages/server/src/graphql/errorField.ts
@@ -1,0 +1,8 @@
+import { GraphQLString } from 'graphql';
+
+export const errorField = {
+  error: {
+    type: GraphQLString,
+    resolve: (response: any) => response.error,
+  },
+};

--- a/packages/server/src/graphql/nodeInterface.ts
+++ b/packages/server/src/graphql/nodeInterface.ts
@@ -1,4 +1,5 @@
 import { fromGlobalId, nodeDefinitions } from 'graphql-relay';
+import { RecipesModel } from '../modules/Recipes/recipesModel';
 import { UserModel } from '../modules/User/userModel';
 
 export const { nodeInterface, nodeField, nodesField } = nodeDefinitions(
@@ -6,12 +7,14 @@ export const { nodeInterface, nodeField, nodesField } = nodeDefinitions(
     const { id: userGlobalID, type } = fromGlobalId(globalId);
 
     if (type === 'User') return await UserModel.findById(userGlobalID);
+    if (type === 'Recipes') return await RecipesModel.findById(userGlobalID);
 
     return null;
   },
   (obj) => {
-    const objName = obj instanceof UserModel ? 'User' : undefined;
+    if (obj instanceof UserModel) return 'User';
+    if (obj instanceof RecipesModel) return 'Recipes';
 
-    return objName;
+    return undefined;
   },
 );

--- a/packages/server/src/modules/Recipes/RecipesMutations/createRecipe.ts
+++ b/packages/server/src/modules/Recipes/RecipesMutations/createRecipe.ts
@@ -1,0 +1,51 @@
+import { GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
+import { mutationWithClientMutationId } from 'graphql-relay';
+import { errorField } from '../../../graphql/errorField';
+import { IAuthContext } from '../../User/auth/findCurrentUser';
+import { RecipesModel } from '../recipesModel';
+import { RecipesType } from '../recipesType';
+
+export interface IRecipeArgs {
+  title: string;
+  ingredients: string;
+  instructions: string;
+}
+
+export const createRecipe = mutationWithClientMutationId({
+  name: 'createRecipe',
+  inputFields: {
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Recipe title',
+    },
+    ingredients: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      description: 'Recipe ingredients',
+    },
+    instructions: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Recipe instructions',
+    },
+  },
+  outputFields: {
+    recipe: {
+      type: RecipesType,
+      resolve: (response) => response.recipe,
+    },
+    ...errorField,
+  },
+  mutateAndGetPayload: async ({ ...args }: IRecipeArgs, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return { error: 'Unauthorized', recipe: null };
+    }
+
+    const newRecipe = new RecipesModel({
+      ...args,
+      userId: ctx.user.id,
+    });
+
+    await newRecipe.save();
+
+    return { recipe: newRecipe };
+  },
+});

--- a/packages/server/src/modules/Recipes/RecipesMutations/deleteRecipe.ts
+++ b/packages/server/src/modules/Recipes/RecipesMutations/deleteRecipe.ts
@@ -1,0 +1,30 @@
+import { GraphQLID, GraphQLString } from 'graphql';
+import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay';
+import { errorField } from '../../../graphql/errorField';
+import { IAuthContext } from '../../User/auth/findCurrentUser';
+import { RecipesModel } from '../recipesModel';
+
+export const deleteRecipe = mutationWithClientMutationId({
+  name: 'deleteRecipe',
+  inputFields: {
+    globalId: { type: GraphQLID },
+  },
+  outputFields: {
+    deletedOutput: {
+      type: GraphQLString,
+      resolve: (response) => response.deletedCount,
+    },
+    ...errorField,
+  },
+  mutateAndGetPayload: async ({ globalId }, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return {
+        error: 'Unauthorized',
+      };
+    }
+
+    const { id } = fromGlobalId(globalId);
+
+    return await RecipesModel.deleteOne({ _id: id });
+  },
+});

--- a/packages/server/src/modules/Recipes/RecipesMutations/recipesMutations.ts
+++ b/packages/server/src/modules/Recipes/RecipesMutations/recipesMutations.ts
@@ -1,0 +1,5 @@
+import { createRecipe } from './createRecipe';
+import { deleteRecipe } from './deleteRecipe';
+import { updateRecipe } from './updateRecipe';
+
+export const recipeMutations = { createRecipe, deleteRecipe, updateRecipe };

--- a/packages/server/src/modules/Recipes/RecipesMutations/updateRecipe.ts
+++ b/packages/server/src/modules/Recipes/RecipesMutations/updateRecipe.ts
@@ -1,0 +1,46 @@
+import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
+import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay';
+import { errorField } from '../../../graphql/errorField';
+import { IAuthContext } from '../../User/auth/findCurrentUser';
+import { RecipesModel } from '../recipesModel';
+import { RecipesType } from '../recipesType';
+
+export const updateRecipe = mutationWithClientMutationId({
+  name: 'updateRecipe',
+  inputFields: {
+    globalId: { type: GraphQLID },
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'Recipe title',
+    },
+    ingredients: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      description: 'Recipe ingredients',
+    },
+    instructions: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      description: 'Recipe instructions',
+    },
+  },
+  outputFields: {
+    recipe: {
+      type: RecipesType,
+      resolve: (response) => response.recipe,
+    },
+    ...errorField,
+  },
+  mutateAndGetPayload: async ({ globalId, ...args }, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return {
+        error: 'Unauthorized',
+      };
+    }
+
+    const { id } = fromGlobalId(globalId);
+
+    await RecipesModel.updateOne({ _id: id }, { ...args });
+
+    const recipe = await RecipesModel.findById(id);
+    return { recipe };
+  },
+});

--- a/packages/server/src/modules/Recipes/RecipesQueries/findAllRecipes.ts
+++ b/packages/server/src/modules/Recipes/RecipesQueries/findAllRecipes.ts
@@ -1,0 +1,20 @@
+import { GraphQLFieldConfig } from 'graphql';
+import { connectionArgs, connectionFromArray } from 'graphql-relay';
+import { IAuthContext } from '../../User/auth/findCurrentUser';
+import { RecipesModel } from '../recipesModel';
+import { RecipesConnection } from '../recipesType';
+
+export const findAllRecipes: GraphQLFieldConfig<any, any, any> = {
+  type: RecipesConnection,
+  args: connectionArgs,
+  resolve: async (_, args, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return {
+        error: 'Unauthorized',
+      };
+    }
+    const recipes = await RecipesModel.find({});
+
+    return connectionFromArray(recipes, args);
+  },
+};

--- a/packages/server/src/modules/Recipes/RecipesQueries/findOneRecipe.ts
+++ b/packages/server/src/modules/Recipes/RecipesQueries/findOneRecipe.ts
@@ -1,0 +1,21 @@
+import { GraphQLFieldConfig, GraphQLID } from 'graphql';
+import { fromGlobalId } from 'graphql-relay';
+import { IAuthContext } from '../../User/auth/findCurrentUser';
+import { RecipesModel } from '../recipesModel';
+import { RecipesType } from '../recipesType';
+
+export const findOneRecipe: GraphQLFieldConfig<any, any, any> = {
+  type: RecipesType,
+  args: { id: { type: GraphQLID } },
+  resolve: async (_, args, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return {
+        error: 'Unauthorized',
+      };
+    }
+
+    const { id } = fromGlobalId(args.id);
+
+    return await RecipesModel.findById(id);
+  },
+};

--- a/packages/server/src/modules/Recipes/RecipesQueries/recipeQueries.ts
+++ b/packages/server/src/modules/Recipes/RecipesQueries/recipeQueries.ts
@@ -1,0 +1,4 @@
+import { findAllRecipes } from './findAllRecipes';
+import { findOneRecipe } from './findOneRecipe';
+
+export const recipeQueries = { findAllRecipes, findOneRecipe };

--- a/packages/server/src/modules/Recipes/recipesModel.ts
+++ b/packages/server/src/modules/Recipes/recipesModel.ts
@@ -1,0 +1,18 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface IRecipes {
+  _id: Types.ObjectId;
+  title: string;
+  ingredients: string[];
+  instructions: string[];
+  userId: Types.ObjectId;
+}
+
+const recipesSchema = new Schema<IRecipes>({
+  title: { type: String, required: true },
+  ingredients: { type: [String], required: true },
+  instructions: { type: [String], required: true },
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+});
+
+export const RecipesModel = model<IRecipes>('Recipes', recipesSchema);

--- a/packages/server/src/modules/Recipes/recipesType.ts
+++ b/packages/server/src/modules/Recipes/recipesType.ts
@@ -1,0 +1,30 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+import { connectionDefinitions, globalIdField } from 'graphql-relay';
+import { nodeInterface } from '../../graphql/nodeInterface';
+import { UserModel } from '../User/userModel';
+import { UserType } from '../User/userType';
+
+export const RecipesType = new GraphQLObjectType({
+  name: 'Recipes',
+  interfaces: [nodeInterface],
+  fields: () => ({
+    id: globalIdField('Recipes'),
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    ingredients: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+    instructions: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+    userId: {
+      type: new GraphQLNonNull(UserType),
+      resolve: async ({ userId }) => await UserModel.findById(userId),
+    },
+  }),
+});
+
+export const { connectionType: RecipesConnection, edgeType: RecipesEdge } =
+  connectionDefinitions({
+    nodeType: RecipesType,
+  });

--- a/packages/server/src/modules/User/UserMutations/deleteUser.ts
+++ b/packages/server/src/modules/User/UserMutations/deleteUser.ts
@@ -1,5 +1,6 @@
 import { GraphQLID, GraphQLString } from 'graphql';
-import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay';
+import { mutationWithClientMutationId } from 'graphql-relay';
+import { IAuthContext } from '../auth/findCurrentUser';
 import { UserModel } from '../userModel';
 
 export const deleteUser = mutationWithClientMutationId({
@@ -13,9 +14,13 @@ export const deleteUser = mutationWithClientMutationId({
       resolve: (response) => response.deletedCount,
     },
   },
-  mutateAndGetPayload: async ({ globalId }) => {
-    const { id } = fromGlobalId(globalId);
+  mutateAndGetPayload: async (_, ctx: IAuthContext) => {
+    if (!ctx.user) {
+      return {
+        error: 'Unauthorized',
+      };
+    }
 
-    return await UserModel.deleteOne({ _id: id });
+    return await UserModel.deleteOne({ _id: ctx.user.id });
   },
 });

--- a/packages/server/src/modules/User/userType.ts
+++ b/packages/server/src/modules/User/userType.ts
@@ -1,17 +1,33 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql';
-import { connectionDefinitions, globalIdField } from 'graphql-relay';
+import {
+  connectionArgs,
+  connectionDefinitions,
+  connectionFromArray,
+  globalIdField,
+} from 'graphql-relay';
 import { nodeInterface } from '../../graphql/nodeInterface';
+import { RecipesModel } from '../Recipes/recipesModel';
+import { RecipesConnection } from '../Recipes/recipesType';
 import { IUser } from './userModel';
 
 export const UserType: GraphQLObjectType<IUser> = new GraphQLObjectType<IUser>({
   name: 'User',
-  description: 'A user who loves to run',
   interfaces: [nodeInterface],
   fields: () => ({
     id: globalIdField(),
     fullName: { type: GraphQLString, description: 'The name of the user' },
     email: { type: GraphQLString },
     password: { type: GraphQLString },
+    recipes: {
+      type: RecipesConnection,
+      description: 'All user recipes',
+      args: connectionArgs,
+      resolve: async (user, args) => {
+        const userRecipes = await RecipesModel.find({ userId: user._id });
+
+        return connectionFromArray([...userRecipes], args);
+      },
+    },
   }),
 });
 

--- a/packages/server/src/schema/mutation.ts
+++ b/packages/server/src/schema/mutation.ts
@@ -1,4 +1,5 @@
 import { GraphQLObjectType } from 'graphql';
+import { recipeMutations } from '../modules/Recipes/RecipesMutations/recipesMutations';
 import { userMutations } from '../modules/User/UserMutations/userMutations';
 
 export const mutation = new GraphQLObjectType({
@@ -6,5 +7,6 @@ export const mutation = new GraphQLObjectType({
   description: 'RootMutationType',
   fields: {
     ...userMutations,
+    ...recipeMutations,
   },
 });

--- a/packages/server/src/schema/query.ts
+++ b/packages/server/src/schema/query.ts
@@ -1,12 +1,14 @@
 import { GraphQLObjectType } from 'graphql';
 import { userQueries } from '../modules/User/UserQueries/userQueries';
 import { nodeField, nodesField } from '../graphql/nodeInterface';
+import { recipeQueries } from '../modules/Recipes/RecipesQueries/recipeQueries';
 
 export const query = new GraphQLObjectType({
   name: 'Query',
   description: 'RootQueryType',
   fields: () => ({
     ...userQueries,
+    ...recipeQueries,
     node: nodeField,
     nodes: nodesField,
   }),


### PR DESCRIPTION
In this PR I've created a new Recipes model and its queries and mutations. I've also connected the Users model to this one, now we can query all recipes made by users and vice versa. The schema can be seen below:

![image](https://user-images.githubusercontent.com/61670871/192116534-3b792d67-c50d-4572-b841-83f78d7ce79f.png)

- createRecipe, updateRecipe, deleteRecipe mutations created
-  findAllRecipes, findOneRecipe queries also created
- UserType now can return all recipes that contain his ID
- Queries and mutations now need a JWT token to be effective  